### PR TITLE
Docs show that os timestamps are non-monotonic

### DIFF
--- a/src/s2_time.erl
+++ b/src/s2_time.erl
@@ -40,7 +40,7 @@ monotonic_us() ->
 -endif.
 
 stamp_test() -> ?assert(stamp()   < stamp()),
-                ?assert(stamp(os) < stamp(os)).
+                ?assert(stamp(now) < stamp(now)).
 
 now_to_microsecs({MegaSecs, Secs, MicroSecs}) ->
   (1000000 * 1000000 * MegaSecs) + (1000000 * Secs) + MicroSecs.


### PR DESCRIPTION
Remove test that relied on false assumption. It failed periodically.